### PR TITLE
fix deprecation notice (wrong method name)

### DIFF
--- a/R/compiler.R
+++ b/R/compiler.R
@@ -64,8 +64,8 @@ specify_model <- function( utility_script, dataset = NULL , output_file = NULL, 
 
 #' @export
 compileUtilityFunction <- function(...) {
-  .Deprecated("specifyModel")
-  specifyModel(...)
+  .Deprecated("specify_model")
+  specify_model(...)
 }
 
 


### PR DESCRIPTION
a small mistake I noticed when helping Ilka make sense of the error message she got.